### PR TITLE
Trafikkseparasjonsskjema. DNL-255

### DIFF
--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -866,7 +866,35 @@
         "line-width": 1,
         "line-color": "#57656b"
       }
-    },{
+    },
+    {
+      "id": "TSEZNE",
+      "type": "fill",
+      "minzoom": 11,
+      "source": "s57",
+      "source-layer": "TSEZNE",
+      "paint": {
+        "fill-color": "#ad5cd1",
+        "fill-opacity": 0.3
+      }
+    },
+    {
+      "id": "TSSBND",
+      "type": "line",
+      "minzoom": 11,
+      "source": "s57",
+      "source-layer": "TSSBND",
+      "paint": {
+        "line-color": "#ad5cd1",
+        "line-width": 4,
+        "line-opacity": 0.3,
+        "line-dasharray": [
+          4,
+          1
+        ]
+      }
+    },
+    {
       "id": "Torrdokk_Grense",
       "type": "line",
       "minzoom": 11,
@@ -1438,7 +1466,8 @@
         ],
         "line-width": 1
       }
-    },{
+    },
+    {
       "id": "LIGHTS_LEG",
       "type": "line",
       "minzoom": 11,
@@ -1537,7 +1566,7 @@
       }
     },
     {
-      "id": "S52_SYMBOL_135",
+      "id": "S52_SYMBOL_ROTATE",
       "type": "symbol",
       "minzoom": 11,
       "source": "s57",
@@ -1545,9 +1574,8 @@
       "filter": [
         "all",
         [
-          "==",
-          "ROTATE",
-          135
+          "has",
+          "ROTATE"
         ],
         [
           "!in",
@@ -1562,7 +1590,11 @@
       "layout": {
         "icon-image": "{SYMBOL}",
         "icon-allow-overlap": true,
-        "icon-rotate": 135
+        "icon-rotate": {
+            "property": "ROTATE",
+            "type": "identity"
+        },
+        "icon-rotation-alignment": "map"
       }
     },{
       "id": "Luftledning",


### PR DESCRIPTION
* Symbolisering av trafikkseparasjonsskjema.
* Støtte for rotering av symboler som ikke bare er rotert 135 grader. Foreløpig kun støtte for rotering ihht kartet, ikke skjermen. Det kan vi endre etterhvert om vi tar med denne informasjonen i s57vt.

Eksempelkart med denne fiksen på https://dnl.maplytic.no/branch/mapstyle-tss/test.html