### PR TITLE
samme farge på MudretOmrade som Dybdelag. DNL-234

### DIFF
--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -816,7 +816,15 @@
       "source": "dnl",
       "source-layer": "MudretOmrade",
       "paint": {
-        "fill-color": "rgba(254,254,254,1)"
+        "fill-color": [
+            "interpolate",
+            ["linear"],
+            ["to-number",["get", "dybdeverdi_min"]],
+            0, "#8cc7ed",
+            10, "#cce9f2",
+            20, "#e7f6fd",
+            2000, "#e7f6fd"
+        ]
       }
     },{
       "id": "Flytebrygge",


### PR DESCRIPTION
Eksempelkart med fiks:
https://dnl.maplytic.no/branch/mudret-omrade/test.html?lat=60.393&lon=5.3114&zoom=16

Tilsvarende fra master-branchen:
https://dnl.maplytic.no/test.html?lat=60.393&lon=5.3114&zoom=16