### PR TITLE
Endre dybdelag og tørrfall datakilde - DNL-258

### DIFF
--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -226,11 +226,32 @@
       }
     },
     
+    	{
+      "interactive": true,
+      "id": "dybdelag_s57",
+      "minzoom": 10,
+      "maxzoom": 12,
+      "type": "fill",
+      "source": "s57",
+      "source-layer": "DEPARE",
+      "paint": {
+      "fill-color": [
+      "interpolate",
+      ["linear"],
+      ["to-number",["get", "DRVAL2"]],
+		0, "#8cc7ed",
+		20, "#8cc7ed",
+		50, "#cce9f2",
+		100, "#e7f6fd",
+		2000, "#e7f6fd"
+      ]
+    }
+    },
+    
 {
       "interactive": true,
       "id": "dybdelag",
-      "minzoom": 10,
-      "maxzoom": 11,
+      "minzoom": 12,
       "type": "fill",
       "source": "dnl",
       "source-layer": "Dybdelag",
@@ -246,12 +267,31 @@
       ]
     }
     },
+    
+    	        {
+      "id": "torrfall_s57",
+      "type": "fill",
+      "source": "s57",
+      "source-layer": "DEPARE",
+      "minzoom": 10,
+	  "maxzoom": 12,
+	  "filter": [     
+          "match",
+                    ["to-string",["get", "DRVAL2"]],
+                    ["", "0.5"],
+                    true,
+                    false               
+      ],
+      "paint": {
+      "fill-color": "#6bbfab"
+      }
+    },
         {
       "id": "torrfall",
       "type": "fill",
       "source": "dnl",
       "source-layer": "Torrfall",
-      "minzoom": 10,
+      "minzoom": 12,
       "paint": {
         "fill-color": "#6bbfab"
       }


### PR DESCRIPTION
Hei Bente og Tore, jeg har begynte å bruke s57 data på zoom nivåer 10 og 11, og bytt til primar data fra zoom nivå 12. Dette vil øke ytelsen av tjenesten når jeg reseed data cachen.