### PR TITLE
Sett zoom nivå for div features - DNL-256

### DIFF
--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -1228,6 +1228,7 @@
     },{
       "id": "BRIDGE_label",
       "type": "symbol",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "BRIDGE",
       "layout": {
@@ -1264,6 +1265,7 @@
     },{
       "id": "Luftspenn_label",
       "type": "symbol",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "CBLOHD",
       "layout": {
@@ -1282,6 +1284,7 @@
     {
       "id": "Cable_submarine",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "CBLSUB",
       "filter": [
@@ -1300,6 +1303,7 @@
     {
       "id": "Cable_6",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "CBLSUB",
       "filter": [
@@ -1318,6 +1322,7 @@
     {
       "id": "Grenser_fiskeri",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "FSHZNE",
       "paint": {
@@ -1344,6 +1349,7 @@
     {
       "id": "Grenser_territorial",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "STSLNE",
       "filter": [
@@ -1362,6 +1368,7 @@
     {
       "id": "Grenser_Caution",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "CTNARE",
       "paint": {
@@ -1401,6 +1408,7 @@
     {
       "id": "Rørledning",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "PIPSOL",
       "layout": {
@@ -1423,6 +1431,7 @@
     {
       "id": "Rørledning_2",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "PIPSOL",
       "filter": [

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -894,7 +894,7 @@
     },{
       "id": "Konstruertkystkontur",
       "type": "line",
-      "minzoom": 11,
+      "minzoom": 12,
       "source": "dnl",
       "source-layer": "Konstruertkystkontur",
       "paint": {
@@ -904,7 +904,7 @@
     },{
       "id": "konst_kyst_l",
       "type": "line",
-      "minzoom": 11,
+      "minzoom": 12,
       "source": "dnl",
       "source-layer": "konst_kyst_l",
       "paint": {
@@ -914,7 +914,7 @@
     },{
       "id": "Kystkontur",
       "type": "line",
-      "minzoom": 11,
+      "minzoom": 12,
       "source": "dnl",
       "source-layer": "Kystkontur",
       "paint": {
@@ -1580,7 +1580,7 @@
     },{
       "id": "Luftledning",
       "type": "line",
-      "minzoom": 11,
+      "minzoom": 12,
       "source": "dnl",
       "source-layer": "linjehindre",
       "paint": {

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -1247,6 +1247,7 @@
     {
       "id": "Luftspenn",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "CBLOHD",
       "filter": [
@@ -1336,6 +1337,7 @@
     {
       "id": "recommended_track",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "RECTRC",
       "paint": {
@@ -1382,6 +1384,7 @@
     {
       "id": "Restricted",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "RESARE",
       "paint": {
@@ -1395,6 +1398,7 @@
     {
       "id": "Ferry",
       "type": "line",
+      "minzoom": 10,
       "source": "s57",
       "source-layer": "FERYRT",
       "paint": {


### PR DESCRIPTION
Sett zoom nivå for rørledninger, kabler, grenser, ferry, restricted og bro og luftspenn labels til 10

Test: https://dnl.maplytic.no/branch/ror_osv_zoom/test.html?lat=59.2&lon=10.5&zoom=6

Master: https://dnl.maplytic.no/test.html?lat=59.2&lon=10.5&zoom=6

