### PR TITLE
ta bort nrl kilden

### DIFF
--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -12,10 +12,6 @@
       "maxzoom":14,
       "tiles": ["https://cache.kartverket.no/dnl/{z}/{x}/{y}.mvt"]
   },
-  "nrl": {
-      "type": "vector",
-      "tiles": ["https://wms.geonorge.no/skwms1/wms.nrl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
-    },
     "fjellskygge2": {
       "type": "raster",
       "tiles": [


### PR DESCRIPTION
Vi trenger ikke lenger NRL tjenesten siden laget vi brukte derfra har blitt inkludert i DNL tjenesten.

test: https://dnl.maplytic.no/branch/nrl/test.html?lat=59.0362&lon=5.66&zoom=10