### PR TITLE
Colour changed to dybdelag

### DIFF
--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -257,8 +257,8 @@
       ["linear"],
       ["to-number",["get", "dybdeverdi_min"]],
       0, "#8cc7ed",
-      10, "#cce9f2",
-      20, "#e7f6fd",
+	5, "#cce9f2",
+      10, "e7f6fd",
       2000, "#e7f6fd"
       ]
     }


### PR DESCRIPTION
Endred dybdelag farge 
#8cc7ed area fill for very-shallow deep water 0.5-5m.
#cce9f2 area fill for medium-shallow water 5-10m.
#e7f6fd area fill for medium deep water >=10m.

Test: https://dnl.maplytic.no/branch/dybdelag_farge1/test.html?lat=59.0362&lon=5.66&zoom=13

Master: https://dnl.maplytic.no/test.html?lat=59.0362&lon=5.66&zoom=13