### PR TITLE
Bruk av pdb for sektorlinjer og nye datakilder dybdedata og flytebrygge

### DIFF
--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -7,12 +7,12 @@
     "maxzoom":14,
       "tiles": ["https://s3-eu-west-1.amazonaws.com/maplytic-blob-public/85d855bc-7151-4d92-9afe-feb1b5c9059f/tile/_dnlvt/{z}/{x}/{y}.mvt"]
     },
-    "dnl_cache": {
+    "dnl": {
       "type": "vector",
       "maxzoom":14,
       "tiles": ["https://cache.kartverket.no/dnl/{z}/{x}/{y}.mvt"]
   },
-	"dnl": {
+	"dnl_mapserver": {
       "type": "vector",
       "maxzoom":14,
       "tiles": ["https://openwms.statkart.no/skwms1/wmstest.dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -12,11 +12,7 @@
       "maxzoom":14,
       "tiles": ["https://cache.kartverket.no/test/dnl/{z}/{x}/{y}.mvt"]
   },
-	"dnl_mapserver": {
-      "type": "vector",
-      "maxzoom":14,
-      "tiles": ["https://openwms.statkart.no/skwms1/wmstest.dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
-  },
+
     "fjellskygge2": {
       "type": "raster",
       "tiles": [

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -1127,9 +1127,7 @@
       "source-layer": "N50Anleggspunkt",
       "filter": ["==", "objtype", "Tårn"],
       "layout": {
-        "visibility": "visible"
-      },
-      "layout": {
+        "visibility": "visible",
         "icon-image": "TOWERS03",
         "icon-allow-overlap": true
       }

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -12,13 +12,6 @@
       "maxzoom":14,
       "tiles": ["https://cache.kartverket.no/test/dnl/{z}/{x}/{y}.mvt"]
   },
-	  
-	"fjellskygge_cache": {
-      "type": "raster",
-      "tiles": [
-        "https://opencache.statkart.no/gatekeeper/gk/gk.open?service=WMS&request=GetMap&version=1.3.0&BGCOLOR=0xFFFFFF&crs=EPSG:3857&bbox={bbox-epsg-3857}&layers=fjellskygge&transparent=true&width=256&height=256&format=image/png"
-    ]
-  },
 
     "fjellskygge2": {
       "type": "raster",
@@ -123,7 +116,7 @@
       "id": "fjellskygge2000",
       "type": "raster",
       "maxzoom": 11,
-      "source": "fjellskygge_cache",
+      "source": "fjellskygge2",
       "raster-opacity": 0.8
     },
     {

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -15,7 +15,7 @@
 	"nye_data": {
       "type": "vector",
       "maxzoom":14,
-      "tiles": ["http://rin-te0031/cgi-bin/dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
+      "tiles": ["https://openwms.statkart.no/skwms1/wmstest.dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
   },
     "fjellskygge2": {
       "type": "raster",

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -15,7 +15,7 @@
 	"nye_data": {
       "type": "vector",
       "maxzoom":14,
-      "tiles": ["https://openwms.statkart.no/skwms1/wmstest.dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
+      "tiles": ["https://openwms.statkart.no/skwms1/wms.dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
   },
     "fjellskygge2": {
       "type": "raster",

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -12,6 +12,11 @@
       "maxzoom":14,
       "tiles": ["https://cache.kartverket.no/dnl/{z}/{x}/{y}.mvt"]
   },
+	"nye_data": {
+      "type": "vector",
+      "maxzoom":14,
+      "tiles": ["http://rin-te0031/cgi-bin/dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
+  },
     "fjellskygge2": {
       "type": "raster",
       "tiles": [
@@ -866,7 +871,7 @@
       "id": "Flytebrygge",
       "type": "fill",
       "minzoom": 11,
-      "source": "dnl",
+      "source": "nye_data",
       "source-layer": "Flytebrygge",
       "paint": {
         "fill-color": "#57656b"
@@ -875,7 +880,7 @@
       "id": "Flytebrygge_Grense",
       "type": "line",
       "minzoom": 11,
-      "source": "dnl",
+      "source": "nye_data",
       "source-layer": "Flytebrygge_Grense",
       "paint": {
         "line-width": 1,
@@ -885,7 +890,7 @@
       "id": "flytebrygge_l",
       "type": "line",
       "minzoom": 11,
-      "source": "dnl",
+      "source": "nye_data",
       "source-layer": "flytebrygge_l",
       "paint": {
         "line-width": 1,
@@ -1560,8 +1565,8 @@
       "id": "LIGHTS_LEG",
       "type": "line",
       "minzoom": 11,
-      "source": "s57",
-      "source-layer": "LIGHTS_LEG",
+      "source": "nye_data",
+      "source-layer": "sektorlinje",
       "paint": {
         "line-color": "#000000",
         "line-width": 0.2,

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -10,7 +10,7 @@
     "dnl": {
       "type": "vector",
       "maxzoom":14,
-      "tiles": ["https://cache.kartverket.no/dnl/{z}/{x}/{y}.mvt"]
+      "tiles": ["https://cache.kartverket.no/test/dnl/{z}/{x}/{y}.mvt"]
   },
 	"dnl_mapserver": {
       "type": "vector",

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -12,6 +12,13 @@
       "maxzoom":14,
       "tiles": ["https://cache.kartverket.no/test/dnl/{z}/{x}/{y}.mvt"]
   },
+	  
+	"fjellskygge_cache": {
+      "type": "raster",
+      "tiles": [
+        "https://opencache.statkart.no/gatekeeper/gk/gk.open?service=WMS&request=GetMap&version=1.3.0&BGCOLOR=0xFFFFFF&crs=EPSG:3857&bbox={bbox-epsg-3857}&layers=fjellskygge&transparent=true&width=256&height=256&format=image/png"
+    ]
+  },
 
     "fjellskygge2": {
       "type": "raster",
@@ -116,7 +123,7 @@
       "id": "fjellskygge2000",
       "type": "raster",
       "maxzoom": 11,
-      "source": "fjellskygge2",
+      "source": "fjellskygge_cache",
       "raster-opacity": 0.8
     },
     {

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -7,15 +7,15 @@
     "maxzoom":14,
       "tiles": ["https://s3-eu-west-1.amazonaws.com/maplytic-blob-public/85d855bc-7151-4d92-9afe-feb1b5c9059f/tile/_dnlvt/{z}/{x}/{y}.mvt"]
     },
-    "dnl": {
+    "dnl_cache": {
       "type": "vector",
       "maxzoom":14,
       "tiles": ["https://cache.kartverket.no/dnl/{z}/{x}/{y}.mvt"]
   },
-	"nye_data": {
+	"dnl": {
       "type": "vector",
       "maxzoom":14,
-      "tiles": ["https://openwms.statkart.no/skwms1/wms.dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
+      "tiles": ["https://openwms.statkart.no/skwms1/wmstest.dnl?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=all&map.imagetype=mvt"]
   },
     "fjellskygge2": {
       "type": "raster",
@@ -871,7 +871,7 @@
       "id": "Flytebrygge",
       "type": "fill",
       "minzoom": 11,
-      "source": "nye_data",
+      "source": "dnl",
       "source-layer": "Flytebrygge",
       "paint": {
         "fill-color": "#57656b"
@@ -880,7 +880,7 @@
       "id": "Flytebrygge_Grense",
       "type": "line",
       "minzoom": 11,
-      "source": "nye_data",
+      "source": "dnl",
       "source-layer": "Flytebrygge_Grense",
       "paint": {
         "line-width": 1,
@@ -890,7 +890,7 @@
       "id": "flytebrygge_l",
       "type": "line",
       "minzoom": 11,
-      "source": "nye_data",
+      "source": "dnl",
       "source-layer": "flytebrygge_l",
       "paint": {
         "line-width": 1,
@@ -1565,7 +1565,7 @@
       "id": "LIGHTS_LEG",
       "type": "line",
       "minzoom": 11,
-      "source": "nye_data",
+      "source": "dnl",
       "source-layer": "sektorlinje",
       "paint": {
         "line-color": "#000000",

--- a/public/mapStyle.json
+++ b/public/mapStyle.json
@@ -260,7 +260,7 @@
       "fill-color": [
       "interpolate",
       ["linear"],
-      ["to-number",["get", "dybdeverdi_min"]],
+      ["to-number",["get", "minimumsdybde"]],
       0.5, "#8cc7ed",
       5, "#cce9f2",
       10, "#e7f6fd",
@@ -822,7 +822,7 @@
       "fill-color": [
       "interpolate",
       ["linear"],
-      ["to-number",["get", "dybdeverdi_min"]],
+      ["to-number",["get", "minimumsdybde"]],
       0.5, "#8cc7ed",
       5, "#cce9f2",
       10, "#e7f6fd",
@@ -860,7 +860,7 @@
         "fill-color": [
             "interpolate",
             ["linear"],
-            ["to-number",["get", "dybdeverdi_min"]],
+            ["to-number",["get", "minimumsdybde"]],
       0.5, "#8cc7ed",
       5, "#cce9f2",
       10, "#e7f6fd",
@@ -1266,8 +1266,8 @@
         ],
 
         "text-size": 9,
-        "symbol-sort-key":["to-number", ["get", "dybdeverdi"]],
-        "text-field":["get", "dybdeverdi"]
+        "symbol-sort-key":["to-number", ["get", "dybde"]],
+        "text-field":["get", "dybde"]
       },
       "paint": {
         "text-color": "#000000",
@@ -1290,8 +1290,8 @@
           "Open Sans Regular"
         ],
         "text-size": 9,
-        "symbol-sort-key":["to-number", ["get", "dybdeverdi"]],
-        "text-field":["get", "dybdeverdi"]
+        "symbol-sort-key":["to-number", ["get", "dybde"]],
+        "text-field":["get", "dybde"]
       },
       "paint": {
         "text-color": "rgba(1,1,1,1)",
@@ -1950,8 +1950,8 @@
           "Open Sans Bold"
         ],
         "text-size": 10,
-        "symbol-sort-key": ["to-number",["get", "dybdeverdi"]],
-        "text-field": ["get", "dybdeverdi"]
+        "symbol-sort-key": ["to-number",["get", "dybde"]],
+        "text-field": ["get", "dybde"]
       },
       "paint": {
         "text-color": "rgba(5,5,5,1)",


### PR DESCRIPTION
Vi har importert sektorlinjer fra PDB og bruker disse istedenfor data fra ECC sin tjenesten.
Vi har også begynt å importere dybdedata fra Geonorge og flytebrygge fra pdb02prd.

Test: https://dnl.maplytic.no/branch/sektorlinjer-dybdedata_flytebrygge/test.html?lat=59.0362&lon=5.66&zoom=13

Master: https://dnl.maplytic.no/test.html?lat=59.0362&lon=5.66&zoom=13